### PR TITLE
remove 'cursor: hand' from all css

### DIFF
--- a/app/assets/stylesheets/dataTables/bootstrap/2/jquery.dataTables.bootstrap.scss
+++ b/app/assets/stylesheets/dataTables/bootstrap/2/jquery.dataTables.bootstrap.scss
@@ -59,7 +59,6 @@ table.table thead .sorting_desc,
 table.table thead .sorting_asc_disabled,
 table.table thead .sorting_desc_disabled {
 	cursor: pointer;
-	*cursor: hand;
 }
 
 table.dataTable thead .sorting { background: image_url('dataTables/sort_both.png') no-repeat center right; }
@@ -130,7 +129,6 @@ div.dataTables_scrollFoot table {
 
 table.DTTT_selectable tbody tr {
 	cursor: pointer;
-	*cursor: hand;
 }
 
 div.DTTT .btn {

--- a/app/assets/stylesheets/dataTables/extras/dataTables.colVis.scss
+++ b/app/assets/stylesheets/dataTables/extras/dataTables.colVis.scss
@@ -15,7 +15,6 @@ ul.ColVis_collection li {
 	padding: 5px 8px;
 	border: 1px solid #999;
 	cursor: pointer;
-	*cursor: hand;
 	font-size: 0.88em;
 	color: black !important;
 	white-space: nowrap;

--- a/app/assets/stylesheets/dataTables/extras/dataTables.tableTools.scss
+++ b/app/assets/stylesheets/dataTables/extras/dataTables.tableTools.scss
@@ -57,7 +57,6 @@ a.DTTT_button {
 	padding: 5px 8px;
 	border: 1px solid #999;
 	cursor: pointer;
-	*cursor: hand;
 	font-size: 0.88em;
 	color: black !important;
 
@@ -215,7 +214,6 @@ button.DTTT_button_collection:hover span {
  */
 table.DTTT_selectable tbody tr {
 	cursor: pointer;
-	*cursor: hand;
 }
 
 table.dataTable tr.DTTT_selected.odd {

--- a/app/assets/stylesheets/dataTables/jquery.dataTables.foundation.scss
+++ b/app/assets/stylesheets/dataTables/jquery.dataTables.foundation.scss
@@ -54,7 +54,6 @@ table.dataTable thead .sorting_desc,
 table.dataTable thead .sorting_asc_disabled,
 table.dataTable thead .sorting_desc_disabled {
 	cursor: pointer;
-	*cursor: hand;
 }
 
 table.dataTable thead .sorting { background: image_url('dataTables/foundation/sort_both.png') no-repeat center right; }
@@ -113,7 +112,6 @@ div.dataTables_scrollFoot table {
 
 table.DTTT_selectable tbody tr {
 	cursor: pointer;
-	*cursor: hand;
 }
 
 div.DTTT {

--- a/app/assets/stylesheets/dataTables/jquery.dataTables.scss
+++ b/app/assets/stylesheets/dataTables/jquery.dataTables.scss
@@ -36,7 +36,6 @@ table.dataTable thead .sorting,
 table.dataTable thead .sorting_asc,
 table.dataTable thead .sorting_desc {
   cursor: pointer;
-  *cursor: hand;
 }
 table.dataTable thead .sorting,
 table.dataTable thead .sorting_asc,
@@ -307,7 +306,6 @@ table.dataTable td {
   text-align: center;
   text-decoration: none !important;
   cursor: pointer;
-  *cursor: hand;
   color: #333 !important;
   border: 1px solid transparent;
 }

--- a/app/assets/stylesheets/dataTables/src/demo_table.css
+++ b/app/assets/stylesheets/dataTables/src/demo_table.css
@@ -79,7 +79,6 @@
 	height: 19px;
 	float: left;
 	cursor: pointer;
-	cursor: hand;
 	color: #111 !important;
 }
 .paginate_disabled_previous:hover, .paginate_enabled_previous:hover,
@@ -154,7 +153,6 @@ table.display thead th {
 	border-bottom: 1px solid black;
 	font-weight: bold;
 	cursor: pointer;
-	* cursor: hand;
 }
 
 table.display tfoot th {
@@ -333,7 +331,6 @@ td.details {
 	padding: 2px 5px;
 	margin: 0 3px;
 	cursor: pointer;
-	*cursor: hand;
 	color: #333 !important;
 }
 

--- a/app/assets/stylesheets/dataTables/src/demo_table_jui.css.scss
+++ b/app/assets/stylesheets/dataTables/src/demo_table_jui.css.scss
@@ -34,14 +34,12 @@
 .paging_two_button .ui-button {
 	float: left;
 	cursor: pointer;
-	cursor: hand;
 }
 
 .paging_full_numbers .ui-button {
 	padding: 2px 6px;
 	margin: 0;
 	cursor: pointer;
-	cursor: hand;
 	color: #333 !important;
 }
 
@@ -69,7 +67,6 @@
 table.display thead th {
 	padding: 3px 0px 3px 10px;
 	cursor: pointer;
-	cursor: hand;
 }
 
 div.dataTables_wrapper .ui-widget-header {
@@ -356,7 +353,6 @@ td.details {
 	padding: 2px 5px;
 	margin: 0 3px;
 	cursor: pointer;
-	*cursor: hand;
 	color: #333 !important;
 }
 

--- a/app/assets/stylesheets/dataTables/src/jquery.dataTables_themeroller.css
+++ b/app/assets/stylesheets/dataTables/src/jquery.dataTables_themeroller.css
@@ -32,7 +32,6 @@ table.dataTable thead .sorting_asc,
 table.dataTable thead .sorting_desc,
 table.dataTable thead .sorting {
   cursor: pointer;
-  *cursor: hand;
 }
 table.dataTable thead th div.DataTables_sort_wrapper {
   position: relative;
@@ -247,7 +246,6 @@ table.dataTable td {
   text-align: center;
   text-decoration: none !important;
   cursor: pointer;
-  *cursor: hand;
   color: #333333 !important;
   border: 1px solid transparent;
 }


### PR DESCRIPTION
### Description

Some bogus CSS in this gem is preventing the `sassc` gem from compiling assets for RBE Rails 4. The bogus CSS is:

1. [An IE hack](https://stackoverflow.com/a/4563656/7014122)
2. A value that hasn't been supported since IE8, and was superceded in IE6, https://quirksmode.org/css/user-interface/cursor.html

So we're just removing it. The proposal is to switch from using the official gem, which hasn't been maintained since 2016, to this fixed Custom Ink fork. Down the line it may be worth looking at replacing the gem entirely. This is used specifically in RBE's `sa_productivity`.

### Changes
* Remove all instances of `cursor: hand` from CSS.